### PR TITLE
Update kitti.py to avoid renaming unwanted part of the path

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,20 +9,19 @@ on:
 
 jobs:
   style-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
       - name: Install dependencies
         run: |
-          sudo apt-get install --yes clang-format-10
-          python -m pip install -U yapf==0.30.0 nbformat pydocstyle==6.0.0
+          python -m pip install -U clang-format==10.0.1.1 yapf==0.30.0 nbformat pydocstyle==6.0.0
       - name: Run style check
         run: |
           python ci/check_style.py

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,16 +9,16 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     env:
       NPROC: 2
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
           path: ~/.ccache
@@ -31,10 +31,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      # Pre-installed 18.04 packages: https://git.io/JfHmW
+      # Pre-installed  packages: https://github.com/actions/runner-images/tree/main/images
       - name: Install ccache
         run: |
           sudo apt-get --yes install ccache

--- a/ml3d/datasets/kitti.py
+++ b/ml3d/datasets/kitti.py
@@ -266,9 +266,10 @@ class KITTISplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path = pc_path.replace('velodyne',
-                                     'label_2').replace('.bin', '.txt')
-        calib_path = label_path.replace('label_2', 'calib')
+        
+        # Replace the last instance of "velodyne" in the path by label_2, and the '.bin' by '.txt'
+        label_path = ("label_2".join(pc_path.rsplit("velodyne", 1))).replace('.bin', '.txt')
+        calib_path = "calib".join(label_path.rsplit("label_2", 1))
 
         pc = self.dataset.read_lidar(pc_path)
         calib = self.dataset.read_calib(calib_path)

--- a/ml3d/datasets/kitti.py
+++ b/ml3d/datasets/kitti.py
@@ -266,9 +266,10 @@ class KITTISplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        
+
         # Replace the last instance of "velodyne" in the path by label_2, and the '.bin' by '.txt'
-        label_path = ("label_2".join(pc_path.rsplit("velodyne", 1))).replace('.bin', '.txt')
+        label_path = ("label_2".join(pc_path.rsplit("velodyne", 1))).replace(
+            '.bin', '.txt')
         calib_path = "calib".join(label_path.rsplit("label_2", 1))
 
         pc = self.dataset.read_lidar(pc_path)

--- a/ml3d/datasets/matterport_objects.py
+++ b/ml3d/datasets/matterport_objects.py
@@ -262,7 +262,7 @@ class MatterportObjectsSplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path =  ("boxes".join(path.rsplit("vpc", 1))).replace('.bin', '.txt')
+        label_path =  ("boxes".join(pc_path.rsplit("pc", 1))).replace('.bin', '.txt')
 
         pc = self.dataset.read_lidar(pc_path)
         label = self.dataset.read_label(label_path)

--- a/ml3d/datasets/matterport_objects.py
+++ b/ml3d/datasets/matterport_objects.py
@@ -262,7 +262,8 @@ class MatterportObjectsSplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path =  ("boxes".join(pc_path.rsplit("pc", 1))).replace('.bin', '.txt')
+        label_path = ("boxes".join(pc_path.rsplit("pc",
+                                                  1))).replace('.bin', '.txt')
 
         pc = self.dataset.read_lidar(pc_path)
         label = self.dataset.read_label(label_path)

--- a/ml3d/datasets/matterport_objects.py
+++ b/ml3d/datasets/matterport_objects.py
@@ -262,7 +262,7 @@ class MatterportObjectsSplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path = pc_path.replace('pc', 'boxes').replace('.bin', '.txt')
+        label_path =  ("boxes".join(path.rsplit("vpc", 1))).replace('.bin', '.txt')
 
         pc = self.dataset.read_lidar(pc_path)
         label = self.dataset.read_label(label_path)

--- a/ml3d/datasets/utils/dataprocessing.py
+++ b/ml3d/datasets/utils/dataprocessing.py
@@ -170,7 +170,7 @@ class DataProcessing:
         weight = num_per_class / float(sum(num_per_class))
         ce_label_weight = 1 / (weight + 0.02)
 
-        return np.expand_dims(ce_label_weight, axis=0)
+        return ce_label_weight
 
     @staticmethod
     def invT(T):

--- a/ml3d/datasets/waymo.py
+++ b/ml3d/datasets/waymo.py
@@ -250,9 +250,8 @@ class WaymoSplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path = pc_path.replace('velodyne',
-                                     'label_all').replace('.bin', '.txt')
-        calib_path = label_path.replace('label_all', 'calib')
+        label_path = ("label_all".join(pc_path.rsplit("velodyne", 1))).replace('.bin', '.txt')
+        calib_path = "calib".join(label_path.rsplit("label_all", 1))
 
         pc = self.dataset.read_lidar(pc_path)
         calib = self.dataset.read_calib(calib_path)

--- a/ml3d/datasets/waymo.py
+++ b/ml3d/datasets/waymo.py
@@ -250,7 +250,8 @@ class WaymoSplit():
 
     def get_data(self, idx):
         pc_path = self.path_list[idx]
-        label_path = ("label_all".join(pc_path.rsplit("velodyne", 1))).replace('.bin', '.txt')
+        label_path = ("label_all".join(pc_path.rsplit("velodyne", 1))).replace(
+            '.bin', '.txt')
         calib_path = "calib".join(label_path.rsplit("label_all", 1))
 
         pc = self.dataset.read_lidar(pc_path)


### PR DESCRIPTION
In get_data method of KITTISplit class, paths are created by renaming some parts of other paths (like replacing 'velodyne' by 'label_2'. This can create problems if you work on full path (i.e. if you have a velodyne directory in the path)